### PR TITLE
Change return signature for resolve_url

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,3 +1,0 @@
-[*.vala]
-indent_size = 4
-indent_style = space

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,3 @@
+[*.vala]
+indent_size = 4
+indent_style = space

--- a/meson.build
+++ b/meson.build
@@ -75,6 +75,7 @@ oparl_test_source = [
     'test/paper.vala',
     'test/consultation.vala',
     'test/file.vala',
+    'test/test_helper.vala',
 ]
 
 libtype = 'so'

--- a/src/oparl.vala
+++ b/src/oparl.vala
@@ -86,6 +86,24 @@ namespace OParl {
     }
 
     /**
+     * The return value of resolve_url.
+     *
+     * status_code needs to be set to the HTTP status code that the executed
+     * request returned, or to -1 if a status code couldn't be determined
+     */
+    public class ResolveUrlResult : GLib.Object {
+        public string resolved_data {get; set;}
+        public bool success {get; set;}
+        public int status_code {get; set;}
+
+        public ResolveUrlResult(string resolved_data, bool success, int status_code) {
+            this.resolved_data = resolved_data;
+            this.success = success;
+            this.status_code = status_code;
+        }
+    }
+
+    /**
      * The programmer's entrypoint into OParl endpoints
      *
      * When you want to start to work with OParl endpoints, the first
@@ -153,16 +171,15 @@ namespace OParl {
                     Client.init();
             }
 
-            int status;
-            string data = this.resolve_url(url, out status);
+            ResolveUrlResult result = this.resolve_url(url);
 
-            if (data != null) {
+            if (result.success) {
                 var system = new System();
                 var parser = new Json.Parser();
                 system.set_client(this);
 
                 try {
-                    parser.load_from_data(data);
+                    parser.load_from_data(result.resolved_data);
                 } catch (GLib.Error e) {
                     throw new ParsingError.INVALID_JSON(_("JSON could not be parsed. Please check the OParl endpoint at '%s' against a linter").printf(url));
                 }
@@ -217,12 +234,8 @@ namespace OParl {
          * one single library, we let you decide how to handle HTTP requests in the
          * application.
          * Please be aware that liboparl likes to be fed with nice unicode-strings.
-         *
-         * Signal has an output parameter that needs to be set to the HTTP-status
-         * code that the executed request returned. If no valid HTTP-status is
-         * achievable, -1 is expected as status value.
          */
-        public signal string? resolve_url (string url, out int status);
+        public signal ResolveUrlResult resolve_url (string url);
 
         /**
          * When this OParl.Client is not in strict mode, this signal will be triggered
@@ -252,8 +265,7 @@ namespace OParl {
         public unowned List<Object> resolve() throws ParsingError {
             if (this.url == null)
                 throw new ParsingError.URL_NULL(_("URLs must not be null."));
-            int status;
-            string data = this.c.resolve_url(this.url, out status);
+            string data = this.c.resolve_url(this.url).resolved_data;
             var parser = new Json.Parser();
             try {
                 parser.load_from_data(data);
@@ -339,8 +351,7 @@ namespace OParl {
         }
 
         public Object parse_url(string url) throws ParsingError requires (url != null) {
-            int status;
-            string data = this.c.resolve_url(url, out status);
+            string data = this.c.resolve_url(url).resolved_data;
             var parser = new Json.Parser();
             try {
                 parser.load_from_data(data);
@@ -399,8 +410,7 @@ namespace OParl {
                     throw new ParsingError.URL_LOOP(_("The list '%s' links 'next' to one of its previous pages"), old_url);
                 }
                 visited_urls.append(url);
-                int status;
-                string data = this.c.resolve_url(url, out status);
+                string data = this.c.resolve_url(this.url).resolved_data;
                 var parser = new Json.Parser();
                 try {
                     parser.load_from_data(data);

--- a/src/oparl.vala
+++ b/src/oparl.vala
@@ -410,7 +410,7 @@ namespace OParl {
                     throw new ParsingError.URL_LOOP(_("The list '%s' links 'next' to one of its previous pages"), old_url);
                 }
                 visited_urls.append(url);
-                string data = this.c.resolve_url(this.url).resolved_data;
+                string data = this.c.resolve_url(url).resolved_data;
                 var parser = new Json.Parser();
                 try {
                     parser.load_from_data(data);

--- a/test/agenda_item.vala
+++ b/test/agenda_item.vala
@@ -41,9 +41,7 @@ namespace OParlTest {
 
             Test.add_func ("/oparl/agenda_item/sane_input", () => {
                 var client = new Client();
-                client.resolve_url.connect((url)=>{
-                    return AgendaItemTest.test_input.get(url);
-                });
+                TestHelper.mock_connect(ref client, AgendaItemTest.test_input, null);
                 System s;
                 try {
                     s = client.open("https://oparl.example.org/");
@@ -83,11 +81,7 @@ namespace OParlTest {
                 Test.skip("Due to fixture conflict with file_sane fixture");
 
                 var client = new Client();
-                client.resolve_url.connect((url)=>{
-                    return AgendaItemTest.test_input.get(url).replace(
-                        "\"https://oparl.example.org/agendaitem/0\"", "1"
-                    );
-                });
+                TestHelper.mock_connect(ref client, AgendaItemTest.test_input, "\"https://oparl.example.org/agendaitem/0\"");
                 try {
                     System s = client.open("https://oparl.example.org/");
                     Body b = s.get_body().nth_data(0);
@@ -102,11 +96,7 @@ namespace OParlTest {
             Test.add_func ("/oparl/agenda_item/wrong_meeting_type", () => {
                 Test.skip("Due to fixture conflict with meeting_sane fixture");
                 var client = new Client();
-                client.resolve_url.connect((url)=>{
-                    return AgendaItemTest.test_input.get(url).replace(
-                        "\"https://oparl.example.org/meeting/0\"", "1"
-                    );
-                });
+                TestHelper.mock_connect(ref client, AgendaItemTest.test_input, "\"https://oparl.example.org/meeting/0\"");
                 try {
                     System s = client.open("https://oparl.example.org/");
                     Body b = s.get_body().nth_data(0);
@@ -120,11 +110,7 @@ namespace OParlTest {
 
             Test.add_func ("/oparl/agenda_item/wrong_number_type", () => {
                 var client = new Client();
-                client.resolve_url.connect((url)=>{
-                    return AgendaItemTest.test_input.get(url).replace(
-                        "\"10.1\"", "1"
-                    );
-                });
+                TestHelper.mock_connect(ref client, AgendaItemTest.test_input, "\"10.1\"");
                 try {
                     System s = client.open("https://oparl.example.org/");
                     Body b = s.get_body().nth_data(0);
@@ -138,11 +124,7 @@ namespace OParlTest {
 
             Test.add_func ("/oparl/agenda_item/wrong_name_type", () => {
                 var client = new Client();
-                client.resolve_url.connect((url)=>{
-                    return AgendaItemTest.test_input.get(url).replace(
-                        "\"Satzungsänderung für Ausschreibungen\"", "1"
-                    );
-                });
+                TestHelper.mock_connect(ref client, AgendaItemTest.test_input, "\"Satzungsänderung für Ausschreibungen\"");
                 try {
                     System s = client.open("https://oparl.example.org/");
                     Body b = s.get_body().nth_data(0);
@@ -156,11 +138,7 @@ namespace OParlTest {
 
             Test.add_func ("/oparl/agenda_item/wrong_public_type", () => {
                 var client = new Client();
-                client.resolve_url.connect((url)=>{
-                    return AgendaItemTest.test_input.get(url).replace(
-                        "true", "\"1\""
-                    );
-                });
+                TestHelper.mock_connect_extra(ref client, AgendaItemTest.test_input, "true", "\"1\"");
                 try {
                     System s = client.open("https://oparl.example.org/");
                     Body b = s.get_body().nth_data(0);
@@ -174,11 +152,7 @@ namespace OParlTest {
 
             Test.add_func ("/oparl/agenda_item/wrong_consultation_type", () => {
                 var client = new Client();
-                client.resolve_url.connect((url)=>{
-                    return AgendaItemTest.test_input.get(url).replace(
-                        "\"https://oparl.example.org/consultation/0\"", "1"
-                    );
-                });
+                TestHelper.mock_connect(ref client, AgendaItemTest.test_input, "\"https://oparl.example.org/consultation/0\"");
                 try {
                     System s = client.open("https://oparl.example.org/");
                     Body b = s.get_body().nth_data(0);
@@ -192,11 +166,7 @@ namespace OParlTest {
 
             Test.add_func ("/oparl/agenda_item/wrong_result_type", () => {
                 var client = new Client();
-                client.resolve_url.connect((url)=>{
-                    return AgendaItemTest.test_input.get(url).replace(
-                        "\"Geändert beschlossen\"", "1"
-                    );
-                });
+                TestHelper.mock_connect(ref client, AgendaItemTest.test_input, "\"Geändert beschlossen\"");
                 try {
                     System s = client.open("https://oparl.example.org/");
                     Body b = s.get_body().nth_data(0);
@@ -210,11 +180,7 @@ namespace OParlTest {
 
             Test.add_func ("/oparl/agenda_item/wrong_resolution_text_type", () => {
                 var client = new Client();
-                client.resolve_url.connect((url)=>{
-                    return AgendaItemTest.test_input.get(url).replace(
-                        "\"Der Beschluss weicht wie folgt vom Antrag ab: ...\"", "1"
-                    );
-                });
+                TestHelper.mock_connect(ref client, AgendaItemTest.test_input, "\"Der Beschluss weicht wie folgt vom Antrag ab: ...\"");
                 try {
                     System s = client.open("https://oparl.example.org/");
                     Body b = s.get_body().nth_data(0);
@@ -228,11 +194,7 @@ namespace OParlTest {
 
             Test.add_func ("/oparl/agenda_item/wrong_start_type", () => {
                 var client = new Client();
-                client.resolve_url.connect((url)=>{
-                    return AgendaItemTest.test_input.get(url).replace(
-                        "\"2012-02-06T12:01:00+00:00\"", "1"
-                    );
-                });
+                TestHelper.mock_connect(ref client, AgendaItemTest.test_input, "\"2012-02-06T12:01:00+00:00\"");
                 try {
                     System s = client.open("https://oparl.example.org/");
                     Body b = s.get_body().nth_data(0);
@@ -246,11 +208,7 @@ namespace OParlTest {
 
             Test.add_func ("/oparl/agenda_item/wrong_end_type", () => {
                 var client = new Client();
-                client.resolve_url.connect((url)=>{
-                    return AgendaItemTest.test_input.get(url).replace(
-                        "\"2012-02-08T14:05:27+00:00\"", "1"
-                    );
-                });
+                TestHelper.mock_connect(ref client, AgendaItemTest.test_input, "\"2012-02-08T14:05:27+00:00\"");
                 try {
                     System s = client.open("https://oparl.example.org/");
                     Body b = s.get_body().nth_data(0);

--- a/test/body.vala
+++ b/test/body.vala
@@ -41,9 +41,7 @@ namespace OParlTest {
 
             Test.add_func ("/oparl/body/sane_input", () => {
                 var client = new Client();
-                client.resolve_url.connect((url)=>{
-                    return BodyTest.test_input.get(url);
-                });
+                TestHelper.mock_connect(ref client, BodyTest.test_input, null);
                 System s;
                 try {
                     s = client.open("https://oparl.example.org/");
@@ -90,11 +88,7 @@ namespace OParlTest {
 
             Test.add_func ("/oparl/body/wrong_id_type", () => {
                 var client = new Client();
-                client.resolve_url.connect((url)=>{
-                    return BodyTest.test_input.get(url).replace(
-                        "\"https://oparl.example.org/body/0\"", "1"
-                    );
-                });
+                TestHelper.mock_connect(ref client, BodyTest.test_input, "\"https://oparl.example.org/body/0\"");
                 try {
                     System s = client.open("https://oparl.example.org/");
                     s.get_body().nth_data(0);
@@ -106,11 +100,7 @@ namespace OParlTest {
 
             Test.add_func ("/oparl/body/wrong_system_type", () => {
                 var client = new Client();
-                client.resolve_url.connect((url)=>{
-                    return BodyTest.test_input.get(url).replace(
-                        "\"https://oparl.example.org/\"", "1"
-                    );
-                });
+                TestHelper.mock_connect(ref client, BodyTest.test_input, "\"https://oparl.example.org/\"");
                 try {
                     System s = client.open("https://oparl.example.org/");
                     s.get_body().nth_data(0);
@@ -122,11 +112,7 @@ namespace OParlTest {
 
             Test.add_func ("/oparl/body/wrong_contact_email_type", () => {
                 var client = new Client();
-                client.resolve_url.connect((url)=>{
-                    return BodyTest.test_input.get(url).replace(
-                        "\"ris@beispielstadt.de\"", "1"
-                    );
-                });
+                TestHelper.mock_connect(ref client, BodyTest.test_input, "\"ris@beispielstadt.de\"");
                 try {
                     System s = client.open("https://oparl.example.org/");
                     s.get_body().nth_data(0);
@@ -138,11 +124,7 @@ namespace OParlTest {
 
             Test.add_func ("/oparl/body/wrong_contact_name_type", () => {
                 var client = new Client();
-                client.resolve_url.connect((url)=>{
-                    return BodyTest.test_input.get(url).replace(
-                        "\"RIS-Betreuung\"", "1"
-                    );
-                });
+                TestHelper.mock_connect(ref client, BodyTest.test_input, "\"RIS-Betreuung\"");
                 try {
                     System s = client.open("https://oparl.example.org/");
                     s.get_body().nth_data(0);
@@ -154,11 +136,7 @@ namespace OParlTest {
 
             Test.add_func ("/oparl/body/wrong_ags_type", () => {
                 var client = new Client();
-                client.resolve_url.connect((url)=>{
-                    return BodyTest.test_input.get(url).replace(
-                        "\"05315000\"", "1"
-                    );
-                });
+                TestHelper.mock_connect(ref client, BodyTest.test_input, "\"05315000\"");
                 try {
                     System s = client.open("https://oparl.example.org/");
                     s.get_body().nth_data(0);
@@ -170,11 +148,7 @@ namespace OParlTest {
 
             Test.add_func ("/oparl/body/wrong_rgs_type", () => {
                 var client = new Client();
-                client.resolve_url.connect((url)=>{
-                    return BodyTest.test_input.get(url).replace(
-                        "\"053150000000\"", "1"
-                    );
-                });
+                TestHelper.mock_connect(ref client, BodyTest.test_input, "\"053150000000\"");
                 try {
                     System s = client.open("https://oparl.example.org/");
                     s.get_body().nth_data(0);
@@ -186,11 +160,7 @@ namespace OParlTest {
 
             Test.add_func ("/oparl/body/wrong_classification_type", () => {
                 var client = new Client();
-                client.resolve_url.connect((url)=>{
-                    return BodyTest.test_input.get(url).replace(
-                        "\"Kreisfreie Stadt\"", "1"
-                    );
-                });
+                TestHelper.mock_connect(ref client, BodyTest.test_input, "\"Kreisfreie Stadt\"");
                 try {
                     System s = client.open("https://oparl.example.org/");
                     s.get_body().nth_data(0);
@@ -206,11 +176,7 @@ namespace OParlTest {
 
             Test.add_func ("/oparl/body/wrong_website_type", () => {
                 var client = new Client();
-                client.resolve_url.connect((url)=>{
-                    return BodyTest.test_input.get(url).replace(
-                        "\"http://www.beispielstadt.de/\"", "1"
-                    );
-                });
+                TestHelper.mock_connect(ref client, BodyTest.test_input, "\"http://www.beispielstadt.de/\"");
                 try {
                     System s = client.open("https://oparl.example.org/");
                     s.get_body().nth_data(0);
@@ -222,11 +188,7 @@ namespace OParlTest {
 
             Test.add_func ("/oparl/body/wrong_license_type", () => {
                 var client = new Client();
-                client.resolve_url.connect((url)=>{
-                    return BodyTest.test_input.get(url).replace(
-                        "\"http://creativecommons.org/licenses/by/4.0/\"", "1"
-                    );
-                });
+                TestHelper.mock_connect(ref client, BodyTest.test_input, "\"http://creativecommons.org/licenses/by/4.0/\"");
                 try {
                     System s = client.open("https://oparl.example.org/");
                     s.get_body().nth_data(0);
@@ -238,11 +200,7 @@ namespace OParlTest {
 
             Test.add_func ("/oparl/body/wrong_license_valid_since_type", () => {
                 var client = new Client();
-                client.resolve_url.connect((url)=>{
-                    return BodyTest.test_input.get(url).replace(
-                        "\"2015-01-01T14:28:31.568+0000\"", "1"
-                    );
-                });
+                TestHelper.mock_connect(ref client, BodyTest.test_input, "\"2015-01-01T14:28:31.568+0000\"");
                 try {
                     System s = client.open("https://oparl.example.org/");
                     s.get_body().nth_data(0);
@@ -254,11 +212,7 @@ namespace OParlTest {
 
             Test.add_func ("/oparl/body/wrong_oparl_since_type", () => {
                 var client = new Client();
-                client.resolve_url.connect((url)=>{
-                    return BodyTest.test_input.get(url).replace(
-                        "\"2014-01-01T14:28:31.568+0000\"", "1"
-                    );
-                });
+                TestHelper.mock_connect(ref client, BodyTest.test_input, "\"2014-01-01T14:28:31.568+0000\"");
                 try {
                     System s = client.open("https://oparl.example.org/");
                     s.get_body().nth_data(0);

--- a/test/consultation.vala
+++ b/test/consultation.vala
@@ -42,9 +42,7 @@ namespace OParlTest {
 
             Test.add_func ("/oparl/consultation/sane_input", () => {
                 var client = new Client();
-                client.resolve_url.connect((url)=>{
-                    return ConsultationTest.test_input.get(url);
-                });
+                TestHelper.mock_connect(ref client, ConsultationTest.test_input, null);
                 System s;
                 try {
                     s = client.open("https://oparl.example.org/");
@@ -74,11 +72,7 @@ namespace OParlTest {
 
             Test.add_func ("/oparl/consultation/wrong_id_type", () => {
                 var client = new Client();
-                client.resolve_url.connect((url)=>{
-                    return ConsultationTest.test_input.get(url).replace(
-                        "\"https://oparl.example.org/consultation/0\"", "1"
-                    );
-                });
+                TestHelper.mock_connect(ref client, ConsultationTest.test_input, "\"https://oparl.example.org/consultation/0\"");
                 try {
                     System s = client.open("https://oparl.example.org/");
                     Body b = s.get_body().nth_data(0);
@@ -92,11 +86,7 @@ namespace OParlTest {
 
             Test.add_func ("/oparl/consultation/wrong_agenda_item_type", () => {
                 var client = new Client();
-                client.resolve_url.connect((url)=>{
-                    return ConsultationTest.test_input.get(url).replace(
-                        "\"https://oparl.example.org/agendaitem/0\"", "1"
-                    );
-                });
+                TestHelper.mock_connect(ref client, ConsultationTest.test_input, "\"https://oparl.example.org/agendaitem/0\"");
                 try {
                     System s = client.open("https://oparl.example.org/");
                     Body b = s.get_body().nth_data(0);
@@ -110,11 +100,7 @@ namespace OParlTest {
 
             Test.add_func ("/oparl/consultation/wrong_meeting_type", () => {
                 var client = new Client();
-                client.resolve_url.connect((url)=>{
-                    return ConsultationTest.test_input.get(url).replace(
-                        "\"https://oparl.example.org/meeting/0\"", "1"
-                    );
-                });
+                TestHelper.mock_connect(ref client, ConsultationTest.test_input, "\"https://oparl.example.org/meeting/0\"");
                 try {
                     System s = client.open("https://oparl.example.org/");
                     Body b = s.get_body().nth_data(0);
@@ -128,11 +114,7 @@ namespace OParlTest {
 
             Test.add_func ("/oparl/consultation/wrong_authoritative_type", () => {
                 var client = new Client();
-                client.resolve_url.connect((url)=>{
-                    return ConsultationTest.test_input.get(url).replace(
-                        "false", "\"1\""
-                    );
-                });
+                TestHelper.mock_connect_extra(ref client, ConsultationTest.test_input, "false", "\"1\"");
                 try {
                     System s = client.open("https://oparl.example.org/");
                     Body b = s.get_body().nth_data(0);
@@ -146,11 +128,7 @@ namespace OParlTest {
 
             Test.add_func ("/oparl/consultation/wrong_role_type", () => {
                 var client = new Client();
-                client.resolve_url.connect((url)=>{
-                    return ConsultationTest.test_input.get(url).replace(
-                        "\"Beschlussfassung\"", "1"
-                    );
-                });
+                TestHelper.mock_connect(ref client, ConsultationTest.test_input, "\"Beschlussfassung\"");
                 try {
                     System s = client.open("https://oparl.example.org/");
                     Body b = s.get_body().nth_data(0);
@@ -165,4 +143,3 @@ namespace OParlTest {
         }
     }
 }
-

--- a/test/file.vala
+++ b/test/file.vala
@@ -42,9 +42,7 @@ namespace OParlTest {
 
             Test.add_func ("/oparl/file/sane_input", () => {
                 var client = new Client();
-                client.resolve_url.connect((url)=>{
-                    return FileTest.test_input.get(url);
-                });
+                TestHelper.mock_connect(ref client, FileTest.test_input, null);
                 System s;
                 try {
                     s = client.open("https://oparl.example.org/");
@@ -87,11 +85,7 @@ namespace OParlTest {
 
             Test.add_func ("/oparl/file/wrong_id_type", () => {
                 var client = new Client();
-                client.resolve_url.connect((url)=>{
-                    return FileTest.test_input.get(url).replace(
-                        "\"https://oparl.example.org/file/0\"", "1"
-                    );
-                });
+                TestHelper.mock_connect(ref client, FileTest.test_input, "\"https://oparl.example.org/file/0\"");
                 try {
                     System s = client.open("https://oparl.example.org/");
                     Body b = s.get_body().nth_data(0);
@@ -105,11 +99,7 @@ namespace OParlTest {
 
             Test.add_func ("/oparl/file/wrong_name_type", () => {
                 var client = new Client();
-                client.resolve_url.connect((url)=>{
-                    return FileTest.test_input.get(url).replace(
-                        "\"Nachtrags-Tagesordnung\"", "1"
-                    );
-                });
+                TestHelper.mock_connect(ref client, FileTest.test_input, "\"Nachtrags-Tagesordnung\"");
                 try {
                     System s = client.open("https://oparl.example.org/");
                     Body b = s.get_body().nth_data(0);
@@ -123,11 +113,7 @@ namespace OParlTest {
 
             Test.add_func ("/oparl/file/wrong_file_name_type", () => {
                 var client = new Client();
-                client.resolve_url.connect((url)=>{
-                    return FileTest.test_input.get(url).replace(
-                        "\"nachtrag-TO.pdf\"", "1"
-                    );
-                });
+                TestHelper.mock_connect(ref client, FileTest.test_input, "\"nachtrag-TO.pdf\"");
                 try {
                     System s = client.open("https://oparl.example.org/");
                     Body b = s.get_body().nth_data(0);
@@ -141,11 +127,7 @@ namespace OParlTest {
 
             Test.add_func ("/oparl/file/wrong_mime_type_type", () => {
                 var client = new Client();
-                client.resolve_url.connect((url)=>{
-                    return FileTest.test_input.get(url).replace(
-                        "\"application/pdf\"", "1"
-                    );
-                });
+                TestHelper.mock_connect(ref client, FileTest.test_input, "\"application/pdf\"");
                 try {
                     System s = client.open("https://oparl.example.org/");
                     Body b = s.get_body().nth_data(0);
@@ -159,11 +141,7 @@ namespace OParlTest {
 
             Test.add_func ("/oparl/file/wrong_date_type", () => {
                 var client = new Client();
-                client.resolve_url.connect((url)=>{
-                    return FileTest.test_input.get(url).replace(
-                        "\"2012-01-08\"", "1"
-                    );
-                });
+                TestHelper.mock_connect(ref client, FileTest.test_input, "\"2012-01-08\"");
                 try {
                     System s = client.open("https://oparl.example.org/");
                     Body b = s.get_body().nth_data(0);
@@ -177,11 +155,7 @@ namespace OParlTest {
 
             Test.add_func ("/oparl/file/wrong_sha1_checksum_type", () => {
                 var client = new Client();
-                client.resolve_url.connect((url)=>{
-                    return FileTest.test_input.get(url).replace(
-                        "\"da39a3ee5e6b4b0d3255bfef95601890afd80709\"", "1"
-                    );
-                });
+                TestHelper.mock_connect(ref client, FileTest.test_input, "\"da39a3ee5e6b4b0d3255bfef95601890afd80709\"");
                 try {
                     System s = client.open("https://oparl.example.org/");
                     Body b = s.get_body().nth_data(0);
@@ -195,11 +169,7 @@ namespace OParlTest {
 
             Test.add_func ("/oparl/file/wrong_size_type", () => {
                 var client = new Client();
-                client.resolve_url.connect((url)=>{
-                    return FileTest.test_input.get(url).replace(
-                        "82930", "\"1\""
-                    );
-                });
+                TestHelper.mock_connect_extra(ref client, FileTest.test_input, "82930", "\"1\"");
                 try {
                     System s = client.open("https://oparl.example.org/");
                     Body b = s.get_body().nth_data(0);
@@ -213,11 +183,7 @@ namespace OParlTest {
 
             Test.add_func ("/oparl/file/wrong_access_url_type", () => {
                 var client = new Client();
-                client.resolve_url.connect((url)=>{
-                    return FileTest.test_input.get(url).replace(
-                        "\"https://oparl.example.org/file/0.pdf\"", "1"
-                    );
-                });
+                TestHelper.mock_connect(ref client, FileTest.test_input, "\"https://oparl.example.org/file/0.pdf\"");
                 try {
                     System s = client.open("https://oparl.example.org/");
                     Body b = s.get_body().nth_data(0);
@@ -231,11 +197,7 @@ namespace OParlTest {
 
             Test.add_func ("/oparl/file/wrong_download_url_type", () => {
                 var client = new Client();
-                client.resolve_url.connect((url)=>{
-                    return FileTest.test_input.get(url).replace(
-                        "\"https://oparl.example.org/file/download/0.pdf\"", "1"
-                    );
-                });
+                TestHelper.mock_connect(ref client, FileTest.test_input, "\"https://oparl.example.org/file/download/0.pdf\"");
                 try {
                     System s = client.open("https://oparl.example.org/");
                     Body b = s.get_body().nth_data(0);
@@ -249,11 +211,7 @@ namespace OParlTest {
 
             Test.add_func ("/oparl/file/wrong_external_service_url_type", () => {
                 var client = new Client();
-                client.resolve_url.connect((url)=>{
-                    return FileTest.test_input.get(url).replace(
-                        "\"https://www.youtube.com/watch?v=MKp30C3MwVk\"", "1"
-                    );
-                });
+                TestHelper.mock_connect(ref client, FileTest.test_input, "\"https://www.youtube.com/watch?v=MKp30C3MwVk\"");
                 try {
                     System s = client.open("https://oparl.example.org/");
                     Body b = s.get_body().nth_data(0);
@@ -267,11 +225,7 @@ namespace OParlTest {
 
             Test.add_func ("/oparl/file/wrong_text_type", () => {
                 var client = new Client();
-                client.resolve_url.connect((url)=>{
-                    return FileTest.test_input.get(url).replace(
-                        "\"blablatextblabla\"", "1"
-                    );
-                });
+                TestHelper.mock_connect(ref client, FileTest.test_input, "\"blablatextblabla\"");
                 try {
                     System s = client.open("https://oparl.example.org/");
                     Body b = s.get_body().nth_data(0);

--- a/test/legislative_term.vala
+++ b/test/legislative_term.vala
@@ -40,9 +40,7 @@ namespace OParlTest {
 
             Test.add_func ("/oparl/legislative_term/sane_input", () => {
                 var client = new Client();
-                client.resolve_url.connect((url)=>{
-                    return LegislativeTermTest.test_input.get(url);
-                });
+                TestHelper.mock_connect(ref client, LegislativeTermTest.test_input, null);
                 System s;
                 try {
                     s = client.open("https://oparl.example.org/");
@@ -67,11 +65,7 @@ namespace OParlTest {
 
             Test.add_func ("/oparl/legislative_term/wrong_id_type", () => {
                 var client = new Client();
-                client.resolve_url.connect((url)=>{
-                    return LegislativeTermTest.test_input.get(url).replace(
-                        "\"https://oparl.example.org/term/21\"", "1"
-                    );
-                });
+                TestHelper.mock_connect(ref client, LegislativeTermTest.test_input, "\"https://oparl.example.org/term/21\"");
                 try {
                     System s = client.open("https://oparl.example.org/");
                     Body b = s.get_body().nth_data(0);
@@ -84,11 +78,7 @@ namespace OParlTest {
 
             Test.add_func ("/oparl/legislative_term/wrong_body_type", () => {
                 var client = new Client();
-                client.resolve_url.connect((url)=>{
-                    return LegislativeTermTest.test_input.get(url).replace(
-                        "\"https://oparl.example.org/body/0\"", "1"
-                    );
-                });
+                TestHelper.mock_connect(ref client, LegislativeTermTest.test_input, "\"https://oparl.example.org/body/0\"");
                 try {
                     System s = client.open("https://oparl.example.org/");
                     Body b = s.get_body().nth_data(0);
@@ -101,11 +91,7 @@ namespace OParlTest {
 
             Test.add_func ("/oparl/legislative_term/wrong_name_type", () => {
                 var client = new Client();
-                client.resolve_url.connect((url)=>{
-                    return LegislativeTermTest.test_input.get(url).replace(
-                        "\"21. Wahlperiode\"", "1"
-                    );
-                });
+                TestHelper.mock_connect(ref client, LegislativeTermTest.test_input, "\"21. Wahlperiode\"");
                 try {
                     System s = client.open("https://oparl.example.org/");
                     Body b = s.get_body().nth_data(0);
@@ -118,11 +104,7 @@ namespace OParlTest {
 
             Test.add_func ("/oparl/legislative_term/wrong_start_date_type", () => {
                 var client = new Client();
-                client.resolve_url.connect((url)=>{
-                    return LegislativeTermTest.test_input.get(url).replace(
-                        "\"2010-12-03\"", "1"
-                    );
-                });
+                TestHelper.mock_connect(ref client, LegislativeTermTest.test_input, "\"2010-12-03\"");
                 try {
                     System s = client.open("https://oparl.example.org/");
                     Body b = s.get_body().nth_data(0);
@@ -135,11 +117,7 @@ namespace OParlTest {
 
             Test.add_func ("/oparl/legislative_term/wrong_end_date_type", () => {
                 var client = new Client();
-                client.resolve_url.connect((url)=>{
-                    return LegislativeTermTest.test_input.get(url).replace(
-                        "\"2013-12-03\"", "1"
-                    );
-                });
+                TestHelper.mock_connect(ref client, LegislativeTermTest.test_input, "\"2013-12-03\"");
                 try {
                     System s = client.open("https://oparl.example.org/");
                     Body b = s.get_body().nth_data(0);

--- a/test/location.vala
+++ b/test/location.vala
@@ -42,9 +42,7 @@ namespace OParlTest {
 
             Test.add_func ("/oparl/location/sane_input", () => {
                 var client = new Client();
-                client.resolve_url.connect((url)=>{
-                    return LocationTest.test_input.get(url);
-                });
+                TestHelper.mock_connect(ref client, LocationTest.test_input, null);
                 System s;
                 try {
                     s = client.open("https://oparl.example.org/");
@@ -80,11 +78,7 @@ namespace OParlTest {
 
             Test.add_func ("/oparl/location/wrong_description_type", () => {
                 var client = new Client();
-                client.resolve_url.connect((url)=>{
-                    return LocationTest.test_input.get(url).replace(
-                        "\"Rathaus der Beispielstadt, Ratshausplatz 1, 12345 Beispielstadt\"", "1"
-                    );
-                });
+                TestHelper.mock_connect(ref client, LocationTest.test_input, "\"Rathaus der Beispielstadt, Ratshausplatz 1, 12345 Beispielstadt\"");
                 try {
                     System s = client.open("https://oparl.example.org/");
                     s.get_body().nth_data(0);
@@ -96,11 +90,7 @@ namespace OParlTest {
 
             Test.add_func ("/oparl/location/wrong_street_address_type", () => {
                 var client = new Client();
-                client.resolve_url.connect((url)=>{
-                    return LocationTest.test_input.get(url).replace(
-                        "\"Rathausplatz 1\"", "1"
-                    );
-                });
+                TestHelper.mock_connect(ref client, LocationTest.test_input, "\"Rathausplatz 1\"");
                 try {
                     System s = client.open("https://oparl.example.org/");
                     s.get_body().nth_data(0);
@@ -112,11 +102,7 @@ namespace OParlTest {
 
             Test.add_func ("/oparl/location/wrong_room_type", () => {
                 var client = new Client();
-                client.resolve_url.connect((url)=>{
-                    return LocationTest.test_input.get(url).replace(
-                        "\"1337\"", "1"
-                    );
-                });
+                TestHelper.mock_connect(ref client, LocationTest.test_input, "\"1337\"");
                 try {
                     System s = client.open("https://oparl.example.org/");
                     s.get_body().nth_data(0);
@@ -128,11 +114,7 @@ namespace OParlTest {
 
             Test.add_func ("/oparl/location/wrong_postal_code_type", () => {
                 var client = new Client();
-                client.resolve_url.connect((url)=>{
-                    return LocationTest.test_input.get(url).replace(
-                        "\"13337\"", "1"
-                    );
-                });
+                TestHelper.mock_connect(ref client, LocationTest.test_input, "\"13337\"");
                 try {
                     System s = client.open("https://oparl.example.org/");
                     s.get_body().nth_data(0);
@@ -144,11 +126,7 @@ namespace OParlTest {
 
             Test.add_func ("/oparl/location/wrong_sub_locality_type", () => {
                 var client = new Client();
-                client.resolve_url.connect((url)=>{
-                    return LocationTest.test_input.get(url).replace(
-                        "\"Beispielbezirk\"", "1"
-                    );
-                });
+                TestHelper.mock_connect(ref client, LocationTest.test_input, "\"Beispielbezirk\"");
                 try {
                     System s = client.open("https://oparl.example.org/");
                     s.get_body().nth_data(0);
@@ -160,11 +138,7 @@ namespace OParlTest {
 
             Test.add_func ("/oparl/location/wrong_locality_type", () => {
                 var client = new Client();
-                client.resolve_url.connect((url)=>{
-                    return LocationTest.test_input.get(url).replace(
-                        "\"Beispielstadt\"", "1"
-                    );
-                });
+                TestHelper.mock_connect(ref client, LocationTest.test_input, "\"Beispielstadt\"");
                 try {
                     System s = client.open("https://oparl.example.org/");
                     s.get_body().nth_data(0);

--- a/test/meeting.vala
+++ b/test/meeting.vala
@@ -41,9 +41,7 @@ namespace OParlTest {
 
             Test.add_func ("/oparl/meeting/sane_input", () => {
                 var client = new Client();
-                client.resolve_url.connect((url)=>{
-                    return MeetingTest.test_input.get(url);
-                });
+                TestHelper.mock_connect(ref client, MeetingTest.test_input, null);
                 System s;
                 try {
                     s = client.open("https://oparl.example.org/");
@@ -87,11 +85,10 @@ namespace OParlTest {
                 client.resolve_url.connect((url)=>{
                     var data = MeetingTest.test_input.get(url);
                     if (url == "https://oparl.example.org/body/0/meetings/")
-                        return data.replace(
+                        data = data.replace(
                             "\"https://oparl.example.org/meeting/0\"", "1"
                         );
-                    else
-                        return data;
+                    return new ResolveUrlResult(data, true, 200);
                 });
                 try {
                     System s = client.open("https://oparl.example.org/");
@@ -105,11 +102,7 @@ namespace OParlTest {
 
             Test.add_func ("/oparl/meeting/wrong_cancelled_type", () => {
                 var client = new Client();
-                client.resolve_url.connect((url)=>{
-                    return MeetingTest.test_input.get(url).replace(
-                        "\"cancelled\": false", "\"cancelled\": \"1\""
-                    );
-                });
+                TestHelper.mock_connect_extra(ref client, MeetingTest.test_input, "\"cancelled\": false", "\"cancelled\": \"1\"");
                 try {
                     System s = client.open("https://oparl.example.org/");
                     Body b = s.get_body().nth_data(0);
@@ -122,11 +115,7 @@ namespace OParlTest {
 
             Test.add_func ("/oparl/meeting/wrong_start_type", () => {
                 var client = new Client();
-                client.resolve_url.connect((url)=>{
-                    return MeetingTest.test_input.get(url).replace(
-                        "\"2013-01-04T08:00:00+00:00\"", "1"
-                    );
-                });
+                TestHelper.mock_connect(ref client, MeetingTest.test_input, "\"2013-01-04T08:00:00+00:00\"");
                 try {
                     System s = client.open("https://oparl.example.org/");
                     Body b = s.get_body().nth_data(0);
@@ -139,11 +128,7 @@ namespace OParlTest {
 
             Test.add_func ("/oparl/meeting/wrong_end_type", () => {
                 var client = new Client();
-                client.resolve_url.connect((url)=>{
-                    return MeetingTest.test_input.get(url).replace(
-                        "\"2013-01-04T12:00:00+00:00\"", "1"
-                    );
-                });
+                TestHelper.mock_connect(ref client, MeetingTest.test_input, "\"2013-01-04T12:00:00+00:00\"");
                 try {
                     System s = client.open("https://oparl.example.org/");
                     Body b = s.get_body().nth_data(0);
@@ -157,11 +142,7 @@ namespace OParlTest {
 
             Test.add_func ("/oparl/meeting/validation_date", () => {
                 var client = new Client();
-                client.resolve_url.connect((url)=>{
-                    return MeetingTest.test_input.get(url).replace(
-                        "\"2013-01-04T12:00:00+00:00\"","\"2013-01-04T06:00:00+00:00\""
-                    );
-                });
+                TestHelper.mock_connect_extra(ref client, MeetingTest.test_input, "\"2013-01-04T12:00:00+00:00\"", "\"2013-01-04T06:00:00+00:00\"");
                 try {
                     System s = client.open("https://oparl.example.org/");
                     Body b = s.get_body().nth_data(0);

--- a/test/membership.vala
+++ b/test/membership.vala
@@ -41,9 +41,7 @@ namespace OParlTest {
 
             Test.add_func ("/oparl/membership/sane_input", () => {
                 var client = new Client();
-                client.resolve_url.connect((url)=>{
-                    return MembershipTest.test_input.get(url);
-                });
+                TestHelper.mock_connect(ref client, MembershipTest.test_input, null);
                 System s;
                 try {
                     s = client.open("https://oparl.example.org/");
@@ -74,11 +72,7 @@ namespace OParlTest {
 
             Test.add_func ("/oparl/membership/wrong_id_type", () => {
                 var client = new Client();
-                client.resolve_url.connect((url)=>{
-                    return MembershipTest.test_input.get(url).replace(
-                        "\"https://oparl.example.org/membership/1\"", "1"
-                    );
-                });
+                TestHelper.mock_connect(ref client, MembershipTest.test_input, "\"https://oparl.example.org/membership/1\"");
                 try {
                     System s = client.open("https://oparl.example.org/");
                     Body b = s.get_body().nth_data(0);
@@ -92,11 +86,7 @@ namespace OParlTest {
 
             Test.add_func ("/oparl/membership/wrong_organization_type", () => {
                 var client = new Client();
-                client.resolve_url.connect((url)=>{
-                    return MembershipTest.test_input.get(url).replace(
-                        "\"https://oparl.example.org/organization/0\"", "1"
-                    );
-                });
+                TestHelper.mock_connect(ref client, MembershipTest.test_input, "\"https://oparl.example.org/organization/0\"");
                 try {
                     System s = client.open("https://oparl.example.org/");
                     Body b = s.get_body().nth_data(0);
@@ -110,11 +100,7 @@ namespace OParlTest {
 
             Test.add_func ("/oparl/membership/wrong_role_type", () => {
                 var client = new Client();
-                client.resolve_url.connect((url)=>{
-                    return MembershipTest.test_input.get(url).replace(
-                        "\"Sachkundige Bürgerin\"", "1"
-                    );
-                });
+                TestHelper.mock_connect(ref client, MembershipTest.test_input, "\"Sachkundige Bürgerin\"");
                 try {
                     System s = client.open("https://oparl.example.org/");
                     Body b = s.get_body().nth_data(0);
@@ -128,11 +114,7 @@ namespace OParlTest {
 
             Test.add_func ("/oparl/membership/wrong_voting_right_type", () => {
                 var client = new Client();
-                client.resolve_url.connect((url)=>{
-                    return MembershipTest.test_input.get(url).replace(
-                        "false", "\"foobar\""
-                    );
-                });
+                TestHelper.mock_connect_extra(ref client, MembershipTest.test_input, "false", "\"foobar\"");
                 try {
                     System s = client.open("https://oparl.example.org/");
                     Body b = s.get_body().nth_data(0);
@@ -146,11 +128,7 @@ namespace OParlTest {
 
             Test.add_func ("/oparl/membership/wrong_start_date_type", () => {
                 var client = new Client();
-                client.resolve_url.connect((url)=>{
-                    return MembershipTest.test_input.get(url).replace(
-                        "\"2013-12-02\"", "1"
-                    );
-                });
+                TestHelper.mock_connect(ref client, MembershipTest.test_input, "\"2013-12-02\"");
                 try {
                     System s = client.open("https://oparl.example.org/");
                     Body b = s.get_body().nth_data(0);
@@ -164,11 +142,7 @@ namespace OParlTest {
 
             Test.add_func ("/oparl/membership/wrong_end_date_type", () => {
                 var client = new Client();
-                client.resolve_url.connect((url)=>{
-                    return MembershipTest.test_input.get(url).replace(
-                        "\"2014-07-27\"", "1"
-                    );
-                });
+                TestHelper.mock_connect(ref client, MembershipTest.test_input, "\"2014-07-27\"");
                 try {
                     System s = client.open("https://oparl.example.org/");
                     Body b = s.get_body().nth_data(0);

--- a/test/object.vala
+++ b/test/object.vala
@@ -37,9 +37,7 @@ namespace OParlTest {
 
             Test.add_func ("/oparl/object/sane_input", () => {
                 var client = new Client();
-                client.resolve_url.connect((url)=>{
-                    return ObjectTest.test_input.get(url);
-                });
+                TestHelper.mock_connect(ref client, ObjectTest.test_input, null);
                 System s;
                 try {
                     s = client.open("https://oparl.example.org/");
@@ -63,11 +61,7 @@ namespace OParlTest {
 
             Test.add_func ("/oparl/object/wrong_id_type", () => {
                 var client = new Client();
-                client.resolve_url.connect((url)=>{
-                    return ObjectTest.test_input.get(url).replace(
-                        "\"https://oparl.example.org/\"", "1"
-                    );
-                });
+                TestHelper.mock_connect(ref client, ObjectTest.test_input, "\"https://oparl.example.org/\"");
                 try {
                     client.open("https://oparl.example.org/");
                     GLib.assert_not_reached();
@@ -78,11 +72,7 @@ namespace OParlTest {
 
             Test.add_func ("/oparl/object/wrong_name_type", () => {
                 var client = new Client();
-                client.resolve_url.connect((url)=>{
-                    return ObjectTest.test_input.get(url).replace(
-                        "\"Testsystem und so\"", "1"
-                    );
-                });
+                TestHelper.mock_connect(ref client, ObjectTest.test_input, "\"Testsystem und so\"");
                 try {
                     client.open("https://oparl.example.org/");
                     GLib.assert_not_reached();
@@ -93,11 +83,7 @@ namespace OParlTest {
 
             Test.add_func ("/oparl/object/wrong_short_name_type", () => {
                 var client = new Client();
-                client.resolve_url.connect((url)=>{
-                    return ObjectTest.test_input.get(url).replace(
-                        "\"Testsystem\"", "1"
-                    );
-                });
+                TestHelper.mock_connect(ref client, ObjectTest.test_input, "\"Testsystem\"");
                 try {
                     client.open("https://oparl.example.org/");
                     GLib.assert_not_reached();
@@ -108,11 +94,7 @@ namespace OParlTest {
 
             Test.add_func ("/oparl/object/wrong_license_type", () => {
                 var client = new Client();
-                client.resolve_url.connect((url)=>{
-                    return ObjectTest.test_input.get(url).replace(
-                        "\"CC-BY-SA\"", "1"
-                    );
-                });
+                TestHelper.mock_connect(ref client, ObjectTest.test_input, "\"CC-BY-SA\"");
                 try {
                     client.open("https://oparl.example.org/");
                     GLib.assert_not_reached();
@@ -123,11 +105,7 @@ namespace OParlTest {
 
             Test.add_func ("/oparl/object/wrong_created_type", () => {
                 var client = new Client();
-                client.resolve_url.connect((url)=>{
-                    return ObjectTest.test_input.get(url).replace(
-                        "\"2016-01-01T13:12:22+00:00\"", "1"
-                    );
-                });
+                TestHelper.mock_connect(ref client, ObjectTest.test_input, "\"2016-01-01T13:12:22+00:00\"");
                 try {
                     client.open("https://oparl.example.org/");
                     GLib.assert_not_reached();
@@ -138,11 +116,7 @@ namespace OParlTest {
 
             Test.add_func ("/oparl/object/wrong_modified_type", () => {
                 var client = new Client();
-                client.resolve_url.connect((url)=>{
-                    return ObjectTest.test_input.get(url).replace(
-                        "\"2016-05-23T21:18:29+00:00\"", "1"
-                    );
-                });
+                TestHelper.mock_connect(ref client, ObjectTest.test_input, "\"2016-05-23T21:18:29+00:00\"");
                 try {
                     client.open("https://oparl.example.org/");
                     GLib.assert_not_reached();
@@ -153,11 +127,7 @@ namespace OParlTest {
 
             Test.add_func ("/oparl/object/wrong_keyword_type", () => {
                 var client = new Client();
-                client.resolve_url.connect((url)=>{
-                    return ObjectTest.test_input.get(url).replace(
-                        "[\"some\",\"neat\",\"object\"]", "1"
-                    );
-                });
+                TestHelper.mock_connect(ref client, ObjectTest.test_input, "[\"some\",\"neat\",\"object\"]");
                 try {
                     client.open("https://oparl.example.org/");
                     GLib.assert_not_reached();
@@ -168,11 +138,7 @@ namespace OParlTest {
 
             Test.add_func ("/oparl/object/wrong_web_type", () => {
                 var client = new Client();
-                client.resolve_url.connect((url)=>{
-                    return ObjectTest.test_input.get(url).replace(
-                        "\"https://foobar.invalid\"", "1"
-                    );
-                });
+                TestHelper.mock_connect(ref client, ObjectTest.test_input, "\"https://foobar.invalid\"");
                 try {
                     client.open("https://oparl.example.org/");
                     GLib.assert_not_reached();
@@ -183,11 +149,7 @@ namespace OParlTest {
 
             Test.add_func ("/oparl/object/wrong_deleted_type", () => {
                 var client = new Client();
-                client.resolve_url.connect((url)=>{
-                    return ObjectTest.test_input.get(url).replace(
-                        "false", "1"
-                    );
-                });
+                TestHelper.mock_connect(ref client, ObjectTest.test_input, "false");
                 try {
                     client.open("https://oparl.example.org/");
                     GLib.assert_not_reached();
@@ -198,9 +160,7 @@ namespace OParlTest {
 
             Test.add_func ("/oparl/object/vendor_attributes", () => {
                 var client = new Client();
-                client.resolve_url.connect((url)=>{
-                    return ObjectTest.test_input.get(url);
-                });
+                TestHelper.mock_connect(ref client, ObjectTest.test_input, null);
                 System s;
                 try {
                     s = client.open("https://oparl.example.org/va");
@@ -213,9 +173,7 @@ namespace OParlTest {
 
             Test.add_func ("/oparl/object/refresh", () => {
                 var client = new Client();
-                ulong handle = client.resolve_url.connect((url)=>{
-                    return ObjectTest.test_input.get(url);
-                });
+                ulong handle = TestHelper.mock_connect(ref client, ObjectTest.test_input, null);
                 System s;
                 try {
                     s = client.open("https://oparl.example.org/va");
@@ -224,11 +182,7 @@ namespace OParlTest {
                 }
                 assert (s.name == "Testsystem und so");
                 client.disconnect(handle);
-                client.resolve_url.connect((url)=>{
-                    return ObjectTest.test_input.get(url).replace(
-                        "Testsystem und so", "Systemtest"
-                    );
-                });
+                TestHelper.mock_connect_extra(ref client, ObjectTest.test_input, "Testsystem und so", "Systemtest");
                 try {
                     s.refresh();
                 } catch (ParsingError e) {

--- a/test/organization.vala
+++ b/test/organization.vala
@@ -41,9 +41,7 @@ namespace OParlTest {
 
             Test.add_func ("/oparl/organization/sane_input", () => {
                 var client = new Client();
-                client.resolve_url.connect((url)=>{
-                    return OrganizationTest.test_input.get(url);
-                });
+                TestHelper.mock_connect(ref client, OrganizationTest.test_input, null);
                 System s;
                 try {
                     s = client.open("https://oparl.example.org/");
@@ -84,11 +82,7 @@ namespace OParlTest {
 
             Test.add_func ("/oparl/organization/wrong_body_type", () => {
                 var client = new Client();
-                client.resolve_url.connect((url)=>{
-                    return OrganizationTest.test_input.get(url).replace(
-                        "\"https://oparl.example.org/body/0\"", "1"
-                    );
-                });
+                TestHelper.mock_connect(ref client, OrganizationTest.test_input, "\"https://oparl.example.org/body/0\"");
                 try {
                     System s = client.open("https://oparl.example.org/");
                     Body b = s.get_body().nth_data(0);
@@ -101,11 +95,7 @@ namespace OParlTest {
 
             Test.add_func ("/oparl/organization/wrong_start_date_type", () => {
                 var client = new Client();
-                client.resolve_url.connect((url)=>{
-                    return OrganizationTest.test_input.get(url).replace(
-                        "\"2012-07-17\"", "1"
-                    );
-                });
+                TestHelper.mock_connect(ref client, OrganizationTest.test_input, "\"2012-07-17\"");
                 try {
                     System s = client.open("https://oparl.example.org/");
                     Body b = s.get_body().nth_data(0);
@@ -118,11 +108,7 @@ namespace OParlTest {
 
             Test.add_func ("/oparl/organization/wrong_end_date_type", () => {
                 var client = new Client();
-                client.resolve_url.connect((url)=>{
-                    return OrganizationTest.test_input.get(url).replace(
-                        "\"2014-07-17\"", "1"
-                    );
-                });
+                TestHelper.mock_connect(ref client, OrganizationTest.test_input, "\"2014-07-17\"");
                 try {
                     System s = client.open("https://oparl.example.org/");
                     Body b = s.get_body().nth_data(0);
@@ -135,11 +121,7 @@ namespace OParlTest {
 
             Test.add_func ("/oparl/organization/wrong_organization_type_type", () => {
                 var client = new Client();
-                client.resolve_url.connect((url)=>{
-                    return OrganizationTest.test_input.get(url).replace(
-                        "\"Gremium\"", "1"
-                    );
-                });
+                TestHelper.mock_connect(ref client, OrganizationTest.test_input, "\"Gremium\"");
                 try {
                     System s = client.open("https://oparl.example.org/");
                     Body b = s.get_body().nth_data(0);
@@ -154,11 +136,7 @@ namespace OParlTest {
 
             Test.add_func ("/oparl/organization/wrong_meeting_type", () => {
                 var client = new Client();
-                client.resolve_url.connect((url)=>{
-                    return OrganizationTest.test_input.get(url).replace(
-                        "\"https://oparl.example.org/organization/0/meetings\"", "1"
-                    );
-                });
+                TestHelper.mock_connect(ref client, OrganizationTest.test_input, "\"https://oparl.example.org/organization/0/meetings\"");
                 try {
                     System s = client.open("https://oparl.example.org/");
                     Body b = s.get_body().nth_data(0);
@@ -173,11 +151,7 @@ namespace OParlTest {
 
             Test.add_func ("/oparl/organization/wrong_classification_type", () => {
                 var client = new Client();
-                client.resolve_url.connect((url)=>{
-                    return OrganizationTest.test_input.get(url).replace(
-                        "\"Ausschuss\"", "1"
-                    );
-                });
+                TestHelper.mock_connect(ref client, OrganizationTest.test_input, "\"Ausschuss\"");
                 try {
                     System s = client.open("https://oparl.example.org/");
                     Body b = s.get_body().nth_data(0);
@@ -190,11 +164,7 @@ namespace OParlTest {
 
             Test.add_func ("/oparl/organization/validation_date", () => {
                 var client = new Client();
-                client.resolve_url.connect((url)=>{
-                    return OrganizationTest.test_input.get(url).replace(
-                        "\"2012-07-17\"","\"2016-01-04\""
-                    );
-                });
+                TestHelper.mock_connect_extra(ref client, OrganizationTest.test_input, "\"2012-07-17\"","\"2016-01-04\"");
                 try {
                     System s = client.open("https://oparl.example.org/");
                     Body b = s.get_body().nth_data(0);
@@ -208,4 +178,3 @@ namespace OParlTest {
         }
     }
 }
-

--- a/test/paper.vala
+++ b/test/paper.vala
@@ -43,9 +43,7 @@ namespace OParlTest {
 
             Test.add_func ("/oparl/paper/sane_input", () => {
                 var client = new Client();
-                client.resolve_url.connect((url)=>{
-                    return PaperTest.test_input.get(url);
-                });
+                TestHelper.mock_connect(ref client, PaperTest.test_input, null);
                 System s;
                 try {
                     s = client.open("https://oparl.example.org/");
@@ -91,12 +89,11 @@ namespace OParlTest {
                 client.resolve_url.connect((url)=>{
                     var data = PaperTest.test_input.get(url);
                     if (url == "https://oparl.example.org/body/0/papers/") {
-                        return data.replace(
+                        data = data.replace(
                             "\"https://oparl.example.org/paper/0\"", "1"
                         );
-                    } else {
-                        return data;
                     }
+                    return new ResolveUrlResult(data, true, 200);
                 });
                 try {
                     System s = client.open("https://oparl.example.org/");
@@ -110,11 +107,7 @@ namespace OParlTest {
 
             Test.add_func ("/oparl/paper/wrong_body_type", () => {
                 var client = new Client();
-                client.resolve_url.connect((url)=>{
-                    return PaperTest.test_input.get(url).replace(
-                        "\"https://oparl.example.org/body/0\"", "1"
-                    );
-                });
+                TestHelper.mock_connect(ref client, PaperTest.test_input, "\"https://oparl.example.org/body/0\"");
                 try {
                     System s = client.open("https://oparl.example.org/");
                     Body b = s.get_body().nth_data(0);
@@ -127,11 +120,7 @@ namespace OParlTest {
 
             Test.add_func ("/oparl/paper/wrong_name_type", () => {
                 var client = new Client();
-                client.resolve_url.connect((url)=>{
-                    return PaperTest.test_input.get(url).replace(
-                        "\"Antwort auf Anfrage 1200/2014\"", "1"
-                    );
-                });
+                TestHelper.mock_connect(ref client, PaperTest.test_input, "\"Antwort auf Anfrage 1200/2014\"");
                 try {
                     System s = client.open("https://oparl.example.org/");
                     Body b = s.get_body().nth_data(0);
@@ -144,11 +133,7 @@ namespace OParlTest {
 
             Test.add_func ("/oparl/paper/wrong_reference_type", () => {
                 var client = new Client();
-                client.resolve_url.connect((url)=>{
-                    return PaperTest.test_input.get(url).replace(
-                        "\"1234/2014\"", "1"
-                    );
-                });
+                TestHelper.mock_connect(ref client, PaperTest.test_input, "\"1234/2014\"");
                 try {
                     System s = client.open("https://oparl.example.org/");
                     Body b = s.get_body().nth_data(0);
@@ -161,11 +146,7 @@ namespace OParlTest {
 
             Test.add_func ("/oparl/paper/wrong_date_type", () => {
                 var client = new Client();
-                client.resolve_url.connect((url)=>{
-                    return PaperTest.test_input.get(url).replace(
-                        "\"2014-04-04\"", "1"
-                    );
-                });
+                TestHelper.mock_connect(ref client, PaperTest.test_input, "\"2014-04-04\"");
                 try {
                     System s = client.open("https://oparl.example.org/");
                     Body b = s.get_body().nth_data(0);
@@ -178,11 +159,7 @@ namespace OParlTest {
 
             Test.add_func ("/oparl/paper/wrong_paper_type_type", () => {
                 var client = new Client();
-                client.resolve_url.connect((url)=>{
-                    return PaperTest.test_input.get(url).replace(
-                        "\"Beantwortung einer Anfrage\"", "1"
-                    );
-                });
+                TestHelper.mock_connect(ref client, PaperTest.test_input, "\"Beantwortung einer Anfrage\"");
                 try {
                     System s = client.open("https://oparl.example.org/");
                     Body b = s.get_body().nth_data(0);

--- a/test/person.vala
+++ b/test/person.vala
@@ -39,9 +39,7 @@ namespace OParlTest {
 
             Test.add_func ("/oparl/person/sane_input", () => {
                 var client = new Client();
-                client.resolve_url.connect((url)=>{
-                    return PersonTest.test_input.get(url);
-                });
+                TestHelper.mock_connect(ref client, PersonTest.test_input, null);
                 System s;
                 try {
                     s = client.open("https://oparl.example.org/");
@@ -81,11 +79,7 @@ namespace OParlTest {
 
             Test.add_func ("/oparl/person/wrong_id_type", () => {
                 var client = new Client();
-                client.resolve_url.connect((url)=>{
-                    return PersonTest.test_input.get(url).replace(
-                        "\"https://oparl.example.org/person/0\"", "1"
-                    );
-                });
+                TestHelper.mock_connect(ref client, PersonTest.test_input, "\"https://oparl.example.org/person/0\"");
                 try {
                     System s = client.open("https://oparl.example.org/");
                     Body b = s.get_body().nth_data(0);
@@ -98,11 +92,7 @@ namespace OParlTest {
 
             Test.add_func ("/oparl/person/wrong_family_name_type", () => {
                 var client = new Client();
-                client.resolve_url.connect((url)=>{
-                    return PersonTest.test_input.get(url).replace(
-                        "\"Mustermann\"", "1"
-                    );
-                });
+                TestHelper.mock_connect(ref client, PersonTest.test_input, "\"Mustermann\"");
                 try {
                     System s = client.open("https://oparl.example.org/");
                     Body b = s.get_body().nth_data(0);
@@ -115,11 +105,7 @@ namespace OParlTest {
 
             Test.add_func ("/oparl/person/wrong_given_name_type", () => {
                 var client = new Client();
-                client.resolve_url.connect((url)=>{
-                    return PersonTest.test_input.get(url).replace(
-                        "\"Max\"", "1"
-                    );
-                });
+                TestHelper.mock_connect(ref client, PersonTest.test_input, "\"Max\"");
                 try {
                     System s = client.open("https://oparl.example.org/");
                     Body b = s.get_body().nth_data(0);
@@ -134,11 +120,7 @@ namespace OParlTest {
 
             Test.add_func ("/oparl/person/wrong_form_of_address_type", () => {
                 var client = new Client();
-                client.resolve_url.connect((url)=>{
-                    return PersonTest.test_input.get(url).replace(
-                        "\"Ratsfrau\"", "1"
-                    );
-                });
+                TestHelper.mock_connect(ref client, PersonTest.test_input, "\"Ratsfrau\"");
                 try {
                     System s = client.open("https://oparl.example.org/");
                     Body b = s.get_body().nth_data(0);
@@ -151,11 +133,7 @@ namespace OParlTest {
 
             Test.add_func ("/oparl/person/wrong_gender_type", () => {
                 var client = new Client();
-                client.resolve_url.connect((url)=>{
-                    return PersonTest.test_input.get(url).replace(
-                        "\"male\"", "1"
-                    );
-                });
+                TestHelper.mock_connect(ref client, PersonTest.test_input, "\"male\"");
                 try {
                     System s = client.open("https://oparl.example.org/");
                     Body b = s.get_body().nth_data(0);

--- a/test/system.vala
+++ b/test/system.vala
@@ -37,9 +37,7 @@ namespace OParlTest {
 
             Test.add_func ("/oparl/system/sane_input", () => {
                 var client = new Client();
-                client.resolve_url.connect((url)=>{
-                    return SystemTest.test_input.get(url);
-                });
+                TestHelper.mock_connect(ref client, SystemTest.test_input, null);
                 System s;
                 try {
                     s = client.open("https://oparl.example.org/");
@@ -74,11 +72,7 @@ namespace OParlTest {
 
             Test.add_func ("/oparl/system/wrong_oparl_version_type", () => {
                 var client = new Client();
-                client.resolve_url.connect((url)=>{
-                    return SystemTest.test_input.get(url).replace(
-                        "\"https://schema.oparl.org/1.0/\"", "1"
-                    );
-                });
+                TestHelper.mock_connect(ref client, SystemTest.test_input, "\"https://schema.oparl.org/1.0/\"");
                 try {
                     client.open("https://oparl.example.org/");
                     GLib.assert_not_reached();
@@ -89,11 +83,7 @@ namespace OParlTest {
 
             Test.add_func ("/oparl/system/wrong_contact_email_type", () => {
                 var client = new Client();
-                client.resolve_url.connect((url)=>{
-                    return SystemTest.test_input.get(url).replace(
-                        "\"info@example.org\"", "1"
-                    );
-                });
+                TestHelper.mock_connect(ref client, SystemTest.test_input, "\"info@example.org\"");
                 try {
                     client.open("https://oparl.example.org/");
                     GLib.assert_not_reached();
@@ -104,11 +94,7 @@ namespace OParlTest {
 
             Test.add_func ("/oparl/system/wrong_contact_name_type", () => {
                 var client = new Client();
-                client.resolve_url.connect((url)=>{
-                    return SystemTest.test_input.get(url).replace(
-                        "\"Allgemeiner OParl Kontakt\"", "1"
-                    );
-                });
+                TestHelper.mock_connect(ref client, SystemTest.test_input, "\"Allgemeiner OParl Kontakt\"");
                 try {
                     client.open("https://oparl.example.org/");
                     GLib.assert_not_reached();
@@ -119,11 +105,7 @@ namespace OParlTest {
 
             Test.add_func ("/oparl/system/wrong_website_type", () => {
                 var client = new Client();
-                client.resolve_url.connect((url)=>{
-                    return SystemTest.test_input.get(url).replace(
-                        "\"http://www.example.org/\"", "1"
-                    );
-                });
+                TestHelper.mock_connect(ref client, SystemTest.test_input, "\"http://www.example.org/\"");
                 try {
                     client.open("https://oparl.example.org/");
                     GLib.assert_not_reached();
@@ -134,11 +116,7 @@ namespace OParlTest {
 
             Test.add_func ("/oparl/system/wrong_vendor_type", () => {
                 var client = new Client();
-                client.resolve_url.connect((url)=>{
-                    return SystemTest.test_input.get(url).replace(
-                        "\"http://example-software.com/\"", "1"
-                    );
-                });
+                TestHelper.mock_connect(ref client, SystemTest.test_input, "\"http://example-software.com/\"");
                 try {
                     client.open("https://oparl.example.org/");
                     GLib.assert_not_reached();
@@ -149,11 +127,7 @@ namespace OParlTest {
 
             Test.add_func ("/oparl/system/wrong_product_type", () => {
                 var client = new Client();
-                client.resolve_url.connect((url)=>{
-                    return SystemTest.test_input.get(url).replace(
-                        "\"http://example-software.com/oparl-server/\"", "1"
-                    );
-                });
+                TestHelper.mock_connect(ref client, SystemTest.test_input, "\"http://example-software.com/oparl-server/\"");
                 try {
                     client.open("https://oparl.example.org/");
                     GLib.assert_not_reached();
@@ -164,11 +138,7 @@ namespace OParlTest {
 
             Test.add_func ("/oparl/system/wrong_other_oparl_versions_type", () => {
                 var client = new Client();
-                client.resolve_url.connect((url)=>{
-                    return SystemTest.test_input.get(url).replace(
-                        "[\"https://oparl2.example.org/\"]", "1"
-                    );
-                });
+                TestHelper.mock_connect(ref client, SystemTest.test_input, "[\"https://oparl2.example.org/\"]");
                 try {
                     client.open("https://oparl.example.org/");
                     GLib.assert_not_reached();

--- a/test/test_helper.vala
+++ b/test/test_helper.vala
@@ -35,9 +35,7 @@ namespace OParlTest {
 
         public static ulong mock_connect_extra(ref Client client, GLib.HashTable<string,string> test_input, string old_value, string new_value) {
             return client.resolve_url.connect((url) => {
-                string resolved_data = test_input.get(url);
-                if (resolved_data != null)
-                resolved_data = resolved_data.replace(old_value, new_value);
+                string resolved_data = test_input.get(url).replace(old_value, new_value);
                 return new ResolveUrlResult(resolved_data, true, 200);
             });
         }

--- a/test/test_helper.vala
+++ b/test/test_helper.vala
@@ -1,0 +1,45 @@
+/********************************************************************
+# Copyright 2016-2017 Daniel 'grindhold' Brendle
+#
+# This file is part of liboparl.
+#
+# liboparl is free software: you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public License
+# as published by the Free Software Foundation, either
+# version 3 of the License, or (at your option) any later
+# version.
+#
+# liboparl is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied
+# warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+# PURPOSE. See the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with liboparl.
+# If not, see http://www.gnu.org/licenses/.
+*********************************************************************/
+
+using OParl;
+
+namespace OParlTest {
+    public class TestHelper {
+        public static ulong mock_connect(ref Client client, GLib.HashTable<string,string> test_input, string? replaced) {
+            return client.resolve_url.connect((url) => {
+                string resolved_data = test_input.get(url);
+                if (replaced != null) {
+                    resolved_data = resolved_data.replace(replaced, "1");
+                }
+                return new ResolveUrlResult(resolved_data, true, 200);
+            });
+        }
+
+        public static ulong mock_connect_extra(ref Client client, GLib.HashTable<string,string> test_input, string old_value, string new_value) {
+            return client.resolve_url.connect((url) => {
+                string resolved_data = test_input.get(url);
+                if (resolved_data != null)
+                resolved_data = resolved_data.replace(old_value, new_value);
+                return new ResolveUrlResult(resolved_data, true, 200);
+            });
+        }
+    }
+}


### PR DESCRIPTION
In python it is impossible to write to a `out` parameter, so `resolve_url` can't be implemented properly. I changed `resolve_url` to return an object with data, status code and a success flag instead. Test methods were changed accordingly, though they are as broken as before.

This is a breaking change.